### PR TITLE
redirected to credits.html

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,13 +1,13 @@
 How to Contribute
 =================
 
-- You should add your name with a link to your website to the [Contributors.md](./Contributors.md).
+- You should add your name with a link to your website to the [credits.html](http://fossasia.github.io/flappy-svg/credits.html).
 - Have a look at the [implementation hints](./hints).
 - When you claim an issue, you need to comment. We can not let you do all the [easy](https://github.com/fossasia/flappy-svg/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aeasy+label%3Agci) issues because they are for people who first contribute to the project, unless we have a lot of them.
 - Create [new branches](http://www.git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging) for pull requests if you do several pull requests or issues at a time, so they can be reviewed independently.
 - If reasonable, each issue should have an own pull request.
 - You can add issues yourself if you want specific improvements of the game. We categorize them into `easy`, `middle` and `hard`.
 - When the issue is tagged as [GCI](https://github.com/fossasia/flappy-svg/labels/GCI), it is possible to solve google codein tasks with it. 
-- All works must be your own creation or you must give proper, license-dependent attribution to the creator. See the [LICENSE](LICENSE) file and [Contributors.md](Contributors.md).
+- All works must be your own creation or you must give proper, license-dependent attribution to the creator. See the [LICENSE](LICENSE) file and [credits.html](http://fossasia.github.io/flappy-svg/credits.html).
 - This must work online and offline and without internet connection.
 - This all is possible to be discussed.

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,4 +1,0 @@
-Contributors
-============
-
-This moved to [credits.html](http://fossasia.github.io/flappy-svg/credits.html).


### PR DESCRIPTION
#58  part 3 done.
redirected all the `contributors.md` to `credits.html`.

@niccokunzmann 
can we remove the `contributors.md` now as it doesn't make sense now.