### PR TITLE
Adding functionality to automatically update the apk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,11 @@ before_script:
   - linkchecker --version
 
 script:
+  - bash update-gradle.sh
   - linkchecker -a --check-extern -f $TRAVIS_BUILD_DIR/ *.html 
+
+after_success:
+  - bash update-apk.sh
 
 cache:
   directories: node_modules

--- a/update-apk.sh
+++ b/update-apk.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+mkdir $HOME/buildApk/
+
+cd master
+cd FlappySVG_Android
+
+cp -R app-release.apk $HOME/buildApk/
+
+cd $HOME
+
+git config --global user.email "noreply@travis.com"
+git config --global user.name "Travis CI" 
+git clone --quiet --branch=apk https://heredroky:$GITHUB_API_KEY@github.com/heredroky/flappy-svg apk > /dev/null
+
+cd apk
+cp -Rf $HOME/buildApk/* FlappySVG-Apk/
+git add -f .
+git commit -m "Travis build pushed [skip ci]"
+git push -fq origin apk > /dev/null
+echo -e "Apk updated"

--- a/update-gradle.sh
+++ b/update-gradle.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+git config --global user.email "noreply@travis.com"
+git config --global user.name "Travis CI" 
+git clone --quiet --branch=master https://heredroky:$GITHUB_API_KEY@github.com/heredroky/flappy-svg master > /dev/null
+cd master
+cd FlappySVG_Android
+chmod +x gradlew
+


### PR DESCRIPTION
This PR solves the issue #250. I created 2 files, one of them builds the gradlew in the folder FlappySVG_Android, and the other generates the apk file in the branch apk, you can check it [here](https://github.com/Heredroky/flappy-svg/tree/apk/FlappySVG-Apk)

Check this image of the generated app working on my phone
![screenshot_20170115-132552](https://cloud.githubusercontent.com/assets/15079370/21965104/aac1b3be-db26-11e6-83e2-fac9acefbd8c.png)

Follow this steps to make this feature work on this repo:

1. Create a branch named `apk` with a folder named `FlappySVG-Apk`
2. Merge this PR
3. Generate a Personal Access Token on Github and check the following options:
![screenshot_20170115443-132552](https://cloud.githubusercontent.com/assets/15079370/21791662/6a1de6ca-d6b2-11e6-844a-226300c95c9d.png)
4. Go to the [Travis flappy-svg page](https://travis-ci.org/fossasia/flappy-svg)
5. Go to settings
6. Go to Environment Variables and create one with the name GITHUB_API_KEY and the value will be the generated Personal Access Token that you created on step 3
7. Replace the following line that you will find in` update-apk.sh`:
`git clone --quiet --branch=apk https://heredroky:$GITHUB_API_KEY@github.com/heredroky/flappy-svg apk > /dev/null`
with:
`git clone --quiet --branch=apk https://fossasia:$GITHUB_API_KEY@github.com/fossasia/flappy-svg apk > /dev/null`
8. Replace the following line that you'll find in `update-gradle.sh`:
`git clone --quiet --branch=master https://heredroky:$GITHUB_API_KEY@github.com/heredroky/flappy-svg master > /dev/null`
with:
`git clone --quiet --branch=master https://fossasia:$GITHUB_API_KEY@github.com/fossasia/flappy-svg master > /dev/null`
9. You are good to go