### PR TITLE
Fix: howToPlay page will show up in chrome browser

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -41,6 +41,7 @@
                 <li><a href="https://github.com/oanarosca">Oana Rosca</a></li>
                 <li><a href="https://github.com/reallyly">Yusrilia H.</a></li>
                 <li><a href="https://github.com/Heredroky">Alejandro Heredia</a></li>
+                <li><a href="https://github.com/tripti1410">Trapti Rahangdale</a></li>
             </ul>
             <h3>Credits To: </h3>
             <ul id="list">

--- a/style/howtoplay.css
+++ b/style/howtoplay.css
@@ -7,5 +7,5 @@ body{
 }
 #embed
 {
-	height:100%;
+	height:100vh;
 }


### PR DESCRIPTION
This PR addresses issue #274 

[http://flappy.fossasia.org/howtoplay.html](url) This was not visible in chrome browser