### PR TITLE
Adding new game over criteria

### DIFF
--- a/javascript/flapping.js
+++ b/javascript/flapping.js
@@ -26,9 +26,11 @@ Flappy.prototype = {
         this.position.y = this.position.y + this.velocity;
         if (this.position.screen.bottom > playfield().height) {
             this.position.screen.bottom = playfield().height;
+			this.isCollided = true;
         }
         if (this.position.screen.top < 0) {
             this.position.screen.top = 0;
+			this.isCollided = true;
         }
 
         this.checkCollision();


### PR DESCRIPTION
Game over screen will activate when the player touches the top or bottom of the game screen, as in the original flappybird