### PR TITLE
resolved issue #273 game over without touching any object

### DIFF
--- a/javascript/flapping.js
+++ b/javascript/flapping.js
@@ -148,10 +148,10 @@ function getCenteredrect(rect){
 function isOverlap(e1, e2) {
     rect1 = getCenteredrect(e1);
     rect2 = getCenteredrect(e2);
-    if (rect1.x < rect2.x + rect2.width &&
-   rect1.x + rect1.width > rect2.x &&
-   rect1.y < rect2.y + rect2.height &&
-   rect1.height + rect1.y > rect2.y)
+    if (rect1.x < rect2.x + rect2.width/2 &&
+   rect1.x + rect1.width/2 > rect2.x &&
+   rect1.y < rect2.y + rect2.height/2 &&
+   rect1.height/2 + rect1.y > rect2.y)
         return true;
     else return false;
 }


### PR DESCRIPTION
resolved issue #273 game over without touching any object by modifying flapping.js isOverlap to add half of width/height to midpoint