### PR TITLE
applying sound when flappy crashed on the roof top or on the ground

### DIFF
--- a/javascript/flapping.js
+++ b/javascript/flapping.js
@@ -4,54 +4,58 @@ function Flappy(layerName) {
     this.position = gameObject(this.layer);
     this._isCollided = false;
     var me = this;
-    this.action = new Action(function(){me.fly()}, function(){me.started()});
+    this.action = new Action(function () { me.fly() }, function () { me.started() });
     document.onmousedown = function () { me.flap() };
 }
 
 Flappy.prototype = {
-    velocity : 0,
-    gravity : 1.8,
-    flapVelocity : -20,
+    velocity: 0,
+    gravity: 1.8,
+    flapVelocity: -20,
 
-    startFlapping : function() {
+    startFlapping: function () {
         this.action.start();
         this.position.show();
     },
-    stopFlapping : function() {
+    stopFlapping: function () {
         this.action.stop();
     },
 
-    fly : function() {
+    fly: function () {
         this.velocity += this.gravity;
         this.position.y = this.position.y + this.velocity;
         if (this.position.screen.bottom > playfield().height) {
             this.position.screen.bottom = playfield().height;
-			this.isCollided = true;
+            if (!this.isCollided) {
+                this.isCollided = true;
+            }
         }
         if (this.position.screen.top < 0) {
             this.position.screen.top = 0;
-			this.isCollided = true;
+            if (!this.isCollided) {
+                this.isCollided = true;
+            }
         }
 
         this.checkCollision();
     },
-    started : function() {
+    started: function () {
         this.position.y = 0;
         this.velocity = 0;
     },
-    flap : function() {
+    flap: function () {
         this.velocity = this.flapVelocity;
-		var flapSound = new Audio("../flappy-svg/Sounds/Flappy.mp3");
-		flapSound.play();
+        var flapSound = new Audio("Sounds/Flappy.mp3");
+        flapSound.play();
     },
-    show : function() {
+    show: function () {
         this.position.show();
     },
-    hide : function() {
+    hide: function () {
         this.position.hide();
     },
 
-    checkCollision : function() {
+    checkCollision: function () {
         var flappy_rect = this.layer.getBoundingClientRect();
         for (i = 0; i < 3; i++) {
             if (i >= obstacles.length)
@@ -60,34 +64,37 @@ Flappy.prototype = {
 
             var c = isOverlap(flappy_rect, o_rect);
 
-            if(!c){
-                var d = isBehind(o_rect,flappy_rect);
-                if(d){
+            if (!c) {
+                var d = isBehind(o_rect, flappy_rect);
+                if (d) {
                     updateScore();
                 }
             } else {
-				var gameOverSound = new Audio("../flappy-svg/Sounds/GameOver.mp3");
-				gameOverSound.play();
-				alert('Game Over :( Final Score: ' + Number(document.getElementById("tspan17169").innerHTML));
-			}
+                var gameOverSound = new Audio("Sounds/GameOver.mp3");
+                gameOverSound.play();
+                alert('Game Over :( Final Score: ' + Number(document.getElementById("tspan17169").innerHTML));
+            }
 
             if (c || o_rect.right < flappy_rect.left)
                 obstacles.push(obstacles.shift());
 
-            this.isCollided = c;
+            if (c && !this.isCollided) {
+                this.isCollided = c;
+            }
         }
     },
 
-    set isCollided(value){
-        if (this._isCollided != value)
+    set isCollided(value) {
+        if (this._isCollided != value) {
             this._isCollided = value;
 
-        //On collision code here.
-        if (this._isCollided)
-       	    onCollision();
+            //On collision code here.
+            if (this._isCollided)
+                onCollision();
+        }
     },
 
-    get isCollided(){
+    get isCollided() {
         return this._isCollided;
     }
 }
@@ -115,10 +122,10 @@ function characterChange(layer) {
     flappy.show();
 }
 
-function stopCharacterChange(){
-window.characterChange=function(){
-	return false;
-}
+function stopCharacterChange() {
+    window.characterChange = function () {
+        return false;
+    }
 }
 
 function startFlapping(layer) {
@@ -134,12 +141,12 @@ function stopFlappingBackgound(name) {
     }
 }
 
-function getCenteredrect(rect){
+function getCenteredrect(rect) {
     centered_rect = {
-        x:rect.left+rect.width/2,
-        y:rect.bottom+rect.height/2,
-        width:rect.width,
-        height:rect.height,
+        x: rect.left + rect.width / 2,
+        y: rect.bottom + rect.height / 2,
+        width: rect.width,
+        height: rect.height,
     };
     return centered_rect;
 }
@@ -149,23 +156,25 @@ function isOverlap(e1, e2) {
     rect1 = getCenteredrect(e1);
     rect2 = getCenteredrect(e2);
     if (rect1.x < rect2.x + rect2.width &&
-   rect1.x + rect1.width > rect2.x &&
-   rect1.y < rect2.y + rect2.height &&
-   rect1.height + rect1.y > rect2.y)
+        rect1.x + rect1.width > rect2.x &&
+        rect1.y < rect2.y + rect2.height &&
+        rect1.height + rect1.y > rect2.y)
         return true;
     else return false;
 }
 
-function onCollision(){
+function onCollision() {
+    var gameOverSound = new Audio("Sounds/GameOver.mp3");
+    gameOverSound.play();
     show_layer('gameover');
     stopAllBackgrounds();
 }
 
-function restartGame(){
+function restartGame() {
     location.reload();
 }
 
 
-function isBehind(r1,r2){
-    return (r1.right<=r2.left);
+function isBehind(r1, r2) {
+    return (r1.right <= r2.left);
 }


### PR DESCRIPTION
# Key change made for issue #319 

1.  Added sound effects for the flappy when crashed on the roof top or at the bottom. 
2. Previously there was the sounds for flappy move and crash but not for crash at the bottom and top so i added sounds for these two events

# Proof of sounds are working at the bottom and roof is this

## Sounds for bottom crash and flappy movement

https://github.com/user-attachments/assets/ab28e3e4-4e5b-47e6-a725-14e44b837da9

## Sounds for top crash and flappy movement

https://github.com/user-attachments/assets/d65bc7cc-cf42-41af-a16f-dfb6287946dd

 ## Sounds for flappy crash with object and flappy movement


https://github.com/user-attachments/assets/b000302e-25cb-4682-93d3-2362f07155dd



